### PR TITLE
Update custom_fields.php

### DIFF
--- a/modules/user_games/custom_fields.php
+++ b/modules/user_games/custom_fields.php
@@ -146,7 +146,7 @@ function exec_ogp_module()
 						}														
 					}
 					
-					if(!empty($value)){
+					if (strlen(trim($value)) > 0) {
 						$updatedSettings[$key] = $value;
 					}
 					


### PR DESCRIPTION
https://www.opengamepanel.org/forum/viewthread.php?thread_id=5931

The conditional needs to be `true` in order to update the custom field. `empty()` isn't appropriate due to `0` being considered empty, nor is `isset` - `$value` will always be set.

Checking the length of $value (after trimming it - removing whitespace) has the same effect. If strlen returns true, insert whatever the user gave - without the trimming.